### PR TITLE
Fix minimap with octablock

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -555,7 +555,7 @@ void Client::step(float dtime)
 		{
 			num_processed_meshes++;
 
-			MinimapMapblock *minimap_mapblock = NULL;
+			std::vector<MinimapMapblock*> minimap_mapblocks;
 			bool do_mapper_update = true;
 
 			MapBlock *block = m_env.getMap().getBlockNoCreateNoEx(r.p);
@@ -565,8 +565,8 @@ void Client::step(float dtime)
 				block->mesh = nullptr;
 
 				if (r.mesh) {
-					minimap_mapblock = r.mesh->moveMinimapMapblock();
-					if (minimap_mapblock == NULL)
+					minimap_mapblocks = r.mesh->moveMinimapMapblocks();
+					if (minimap_mapblocks.empty())
 						do_mapper_update = false;
 
 					bool is_empty = true;
@@ -593,8 +593,16 @@ void Client::step(float dtime)
 					block->solid_sides = p.second;
 			}
 
-			if (m_minimap && do_mapper_update)
-				m_minimap->addBlock(r.p, minimap_mapblock);
+			if (m_minimap && do_mapper_update) {
+				v3s16 ofs;
+				for (ofs.Z = 0; ofs.Z <= 1; ofs.Z++)
+				for (ofs.Y = 0; ofs.Y <= 1; ofs.Y++)
+				for (ofs.X = 0; ofs.X <= 1; ofs.X++) {
+					size_t i = ofs.Z * 4 + ofs.Y * 2 + ofs.X;
+					if (i < minimap_mapblocks.size() && minimap_mapblocks[i])
+						m_minimap->addBlock(r.p + ofs, minimap_mapblocks[i]);
+				}
+			}
 
 			for (auto p : r.ack_list) {
 				if (blocks_to_ack.size() == 255) {

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -199,11 +199,11 @@ public:
 		return m_mesh[layer];
 	}
 
-	MinimapMapblock *moveMinimapMapblock()
+	std::vector<MinimapMapblock*> moveMinimapMapblocks()
 	{
-		MinimapMapblock *p = m_minimap_mapblock;
-		m_minimap_mapblock = NULL;
-		return p;
+		std::vector<MinimapMapblock*> minimap_mapblocks;
+		minimap_mapblocks.swap(m_minimap_mapblocks);
+		return minimap_mapblocks;
 	}
 
 	bool isAnimationForced() const
@@ -241,7 +241,7 @@ private:
 	};
 
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
-	MinimapMapblock *m_minimap_mapblock;
+	std::vector<MinimapMapblock*> m_minimap_mapblocks;
 	ITextureSource *m_tsrc;
 	IShaderSource *m_shdrsrc;
 


### PR DESCRIPTION
Mapblock meshes at even coordinates now generate minimap mapblocks for their whole octablock. I added the check for ignore in the voxelmanip to prevent areas filled with ignore from showing up on the minimap, which was a problem.

Sorry if the code is poor, I haven't touched mesh generation much.