### PR TITLE
Only ack block back to server if requested

### DIFF
--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -132,7 +132,8 @@ bool MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 	*/
 	QueuedMeshUpdate *q = new QueuedMeshUpdate;
 	q->p = p;
-	q->ack_list.push_back(original_block);
+	if(ack_block_to_server)
+		q->ack_list.push_back(original_block);
 	q->crack_level = m_client->getCrackLevel();
 	q->crack_pos = m_client->getCrackPos();
 	q->urgent = urgent;


### PR DESCRIPTION
Minor fix.

Thought the "glitches" perhaps had to do with incorrect acks to the server. Found this, but it does not cause the glitches. Still good to fix.