### PR TITLE
Reset usage timers for all blocks in range.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -525,14 +525,18 @@ void ClientMap::touchMapBlocks()
 				if not seen on display
 			*/
 
-			if (!block->mesh) {
-				// Ignore if mesh doesn't exist
-				continue;
+			v3f mesh_sphere_center;
+			f32 mesh_sphere_radius;
+			if (block->mesh) {
+				mesh_sphere_center = intToFloat(block->getPosRelative(), BS)
+						+ block->mesh->getBoundingSphereCenter();
+				mesh_sphere_radius = block->mesh->getBoundingRadius();
+			}
+			else {
+				mesh_sphere_center = intToFloat(block->getPosRelative(), BS) + v3f((MAP_BLOCKSIZE * 0.5f - 0.5f) * BS);
+				mesh_sphere_radius = 0.0f;
 			}
 
-			v3f mesh_sphere_center = intToFloat(block->getPosRelative(), BS)
-					+ block->mesh->getBoundingSphereCenter();
-			f32 mesh_sphere_radius = block->mesh->getBoundingRadius();
 			// First, perform a simple distance check.
 			if (!m_control.range_all &&
 				mesh_sphere_center.getDistanceFrom(intToFloat(cam_pos_nodes, BS)) >
@@ -541,7 +545,8 @@ void ClientMap::touchMapBlocks()
 
 			// Keep the block alive as long as it is in range.
 			block->resetUsageTimer();
-			blocks_in_range_with_mesh++;
+			if (block->mesh)
+				blocks_in_range_with_mesh++;
 		}
 	}
 	g_profiler->avg("MapBlock meshes in range [#]", blocks_in_range_with_mesh);


### PR DESCRIPTION
Resets usage timers of non-meshed blocks as well.

~~Note that this (and the same logic in updateDrawList) is not fully correct. Center and bounding box of the meshes for the meshed blocks are the 2x2x2 meshes and so they are not representing the size of that block.~~

Or maybe it is... We do not want to expire the mesh-holding blocks until the entire mesh is not visible.