### PR TITLE
Only add mesh-blocks to the de-dup shortlist.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -372,9 +372,13 @@ void ClientMap::updateDrawList()
 		}
 
 		// Block meshes are stored in blocks where all coordinates are even (lowest bit set to 0)
-		// We add both the current block and the block with mesh to the set.
-		shortlist.emplace(block_coord.X, block_coord.Y, block_coord.Z);
+		// Add them to the de-dup set.
 		shortlist.emplace(block_coord.X & ~1, block_coord.Y & ~1, block_coord.Z & ~1);
+		// All other blocks we can grab and add to the drawlist right away.
+		if (block && m_drawlist.emplace(block_coord, block).second) {
+			// only grab the ref if the block exists and was not in the list
+			block->refGrab();
+		}
 
 		// Decide which sides to traverse next or to block away
 
@@ -478,9 +482,9 @@ void ClientMap::updateDrawList()
 
 	for (auto pos : shortlist) {
 		MapBlock * block = getBlockNoCreateNoEx(pos);
-		if (block) {
+		if (block && m_drawlist.emplace(pos, block).second) {
+			// only grab the ref if the block exists and was not in the list
 			block->refGrab();
-			m_drawlist.emplace(pos, block);
 		}
 	}
 


### PR DESCRIPTION
This avoids:
1. Adding all visible blocks to the shortlist, and then to the drawlist
2. Regetting all visible non-mesh blocks from the map again, we had references to all of them in the main loop.

This avoids a performance problem when most blocks are visible, such as when you look up in the sky.
